### PR TITLE
docs: move spaces between badges out of link texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,26 @@
 </p>
 <p align="center">
   <a href="https://github.com/iandxssxx" target="_black">
-    <img src="https://img.shields.io/badge/Author-%20IanDxSSXX%20-a046c2.svg?&logo=github" alt="author" />
-  </a>
+    <img src="https://img.shields.io/badge/Author-%20IanDxSSXX%20-a046c2.svg?&logo=github" alt="author"
+  /></a>
   <a href="https://www.github.com/dlight-js/dlight/stargazers" target="_black">
-    <img src="https://img.shields.io/github/stars/dlight-js/dlight?logo=github" alt="stars" />
-  </a>
+    <img src="https://img.shields.io/github/stars/dlight-js/dlight?logo=github" alt="stars"
+  /></a>
   <a href="https://cdn.jsdelivr.net/npm/@dlightjs/dlight"><img src="https://img.shields.io/bundlephobia/minzip/@dlightjs/dlight.svg?label=Size&logo=javascript&color=0ec946" alt="Size"></a>
   <a href="https://www.github.com/dlight-js/dlight/blob/master/LICENSE" target="_black">
-    <img src="https://img.shields.io/github/license/dlight-js/dlight?color=%232DCE89&logo=github" alt="license" />
-  </a>
+    <img src="https://img.shields.io/github/license/dlight-js/dlight?color=%232DCE89&logo=github" alt="license"
+  /></a>
 </p>
 <p align="center">
   <a href="https://www.npmjs.com/package/@dlightjs/dlight" target="_black">
-    <img src="https://img.shields.io/npm/dm/@dlightjs/dlight?color=%23b8072b&logo=npm" alt="downloads" />
-  </a>
+    <img src="https://img.shields.io/npm/dm/@dlightjs/dlight?color=%23b8072b&logo=npm" alt="downloads"
+  /></a>
   <a href="https://www.npmjs.com/package/@dlightjs/dlight" target="_black">
-    <img src="https://img.shields.io/npm/v/@dlightjs/dlight?logo=npm&label=core" alt="version" />
-  </a>
+    <img src="https://img.shields.io/npm/v/@dlightjs/dlight?logo=npm&label=core" alt="version"
+  /></a>
   <a href="https://www.npmjs.com/package/babel-preset-dlight" target="_black">
-    <img src="https://img.shields.io/npm/v/babel-preset-dlight?logo=npm&label=transpiler" alt="version" />
-  </a>
+    <img src="https://img.shields.io/npm/v/babel-preset-dlight?logo=npm&label=transpiler" alt="version"
+  /></a>
 </p>
 
 # [dlight.dev](https://dlight.dev)


### PR DESCRIPTION
Similar to https://github.com/typst/typst/pull/2866.

Before
https://github.com/dlight-js/dlight/blob/1dec7af0529371efab2c4b0344df8c9132dfe3f9/README.md
![image](https://github.com/dlight-js/dlight/assets/6376638/29f872a2-9c91-4350-9192-27aab2a7be5d)

After
https://github.com/muzimuzhi/dlight/blob/c5004f60a1065c1b6610ce63e33671e4dac85222/README.md
![image](https://github.com/dlight-js/dlight/assets/6376638/19cd2dbf-0b9e-4a6b-a31f-e8f6ce2adb04)