### PR TITLE
fix: use function typing

### DIFF
--- a/packages/core/dlight/src/types/model.d.ts
+++ b/packages/core/dlight/src/types/model.d.ts
@@ -19,7 +19,7 @@ type GetContent<T> = ContentKeyName<T> extends undefined
     ? U
     : never
 
-export const use: <M>(
+export const use: <M extends new () => unknown>(
   model: M,
   // @ts-expect-error Model should be a function
   props?: GetProps<Parameters<M>[0]>,


### PR DESCRIPTION
If I use a factory function to bounded a model, it does not have typescript error.

Example:
<img width="612" alt="image" src="https://github.com/dlight-js/dlight/assets/166735097/7e7e03c1-f389-4b73-a9f8-543bd54eaccc">

<img width="745" alt="image" src="https://github.com/dlight-js/dlight/assets/166735097/a685ac2b-d61d-4a31-8d73-d8b388491757">

This is not correct typing, so add `extends new () => unknown`to restrict.