### PR TITLE
WIP: explore svg elements with createSVGElement

### DIFF
--- a/packages/core/babel-preset-dlight/src/const.ts
+++ b/packages/core/babel-preset-dlight/src/const.ts
@@ -238,6 +238,7 @@ export const dlightDefaultPackageName = "@dlightjs/dlight"
 export const importMap = Object.fromEntries(
   [
     "createElement",
+    "createSVGElement",
     "setStyle",
     "setDataset",
     "setEvent",

--- a/packages/core/dlight/src/HTMLNode.js
+++ b/packages/core/dlight/src/HTMLNode.js
@@ -124,6 +124,15 @@ export function createElement(tag) {
 }
 
 /**
+ * @brief Shortcut for document.createElementNS
+ * @param tag Tag name, e.g. 'svg', 'circle', etc.
+ * @returns HTMLElement
+ */
+export function createSVGElement(tag) {
+  return DLStore.document.createElementNS("http://www.w3.org/2000/svg", tag)
+}
+
+/**
  * @brief Insert any DLNode into an element, set the _$nodes and append the element to the element's children
  * @param el
  * @param node

--- a/packages/core/transpiler/view-generator/src/NodeGenerators/HTMLGenerator.ts
+++ b/packages/core/transpiler/view-generator/src/NodeGenerators/HTMLGenerator.ts
@@ -69,9 +69,16 @@ export default class HTMLGenerator extends HTMLPropGenerator {
       this.t.assignmentExpression(
         "=",
         this.t.identifier(dlNodeName),
-        this.t.callExpression(this.t.identifier(this.importMap.createElement), [
-          tag,
-        ])
+        tag.type === "StringLiteral" &&
+          (tag.value === "svg" || tag.value === "circle")
+          ? this.t.callExpression(
+              this.t.identifier(this.importMap.createSVGElement),
+              [tag]
+            )
+          : this.t.callExpression(
+              this.t.identifier(this.importMap.createElement),
+              [tag]
+            )
       )
     )
   }


### PR DESCRIPTION
This PR is a sample PR introducing the concept of a call to createElementNS (via createSVGElement). This allows SVG elements to be rendered in DLight.

Context:
- currently, DLight does not support SVG. Elements such as `svg` are created using the default `createElement` function, which is HTML-only. They are ignored by the browser, and no SVG is rendered.

Current limitations of this exploratory PR:
- only works with `svg` and `circle` elements

Future questions:
- would it be possible to add all SVG element tag names to a defaultSVGTags set? what about tags that exist in both namespaces (e.g. `a`, `title`, `script`, `font` etc.)
- perhaps detecting if a tag is a child of an SVG element tag should automatically cause DLight to tag it as belonging to the SVG namespace?
- more broadly: What is the most elegant and dX-friendly way of making SVG work in DLight?