### PR TITLE
chore: typescript dependency at workspace root

### DIFF
--- a/apps/ToDoMVC/package.json
+++ b/apps/ToDoMVC/package.json
@@ -12,7 +12,6 @@
     "@dlightjs/dlight": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
     "vite": "^6.0.11",
     "vite-plugin-dlight": "workspace:*"
   },

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -18,7 +18,6 @@
     "babel-preset-dlight": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
     "vite": "^6.0.11",
     "vite-plugin-dlight": "workspace:*"
   },

--- a/packages/core/babel-preset-dlight/package.json
+++ b/packages/core/babel-preset-dlight/package.json
@@ -31,8 +31,7 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
-    "@types/node": "^20.10.5",
-    "typescript": "^5.3.2"
+    "@types/node": "^20.10.5"
   },
   "tsup": {
     "entry": [

--- a/packages/core/transpiler/reactivity-parser/package.json
+++ b/packages/core/transpiler/reactivity-parser/package.json
@@ -29,7 +29,6 @@
     "@babel/core": "^7.20.12",
     "@types/babel__core": "^7.20.5",
     "@vitest/ui": "^0.34.5",
-    "typescript": "^5.3.2",
     "vitest": "^0.34.5"
   },
   "tsup": {

--- a/packages/core/transpiler/view-generator/package.json
+++ b/packages/core/transpiler/view-generator/package.json
@@ -27,7 +27,6 @@
     "@babel/core": "^7.20.12",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^20.10.5",
-    "typescript": "^5.3.2",
     "@dlightjs/reactivity-parser": "workspace:*"
   },
   "tsup": {

--- a/packages/core/transpiler/view-parser/package.json
+++ b/packages/core/transpiler/view-parser/package.json
@@ -28,7 +28,6 @@
     "@babel/core": "^7.20.12",
     "@types/babel__core": "^7.20.5",
     "@vitest/ui": "^0.34.5",
-    "typescript": "^5.3.2",
     "vitest": "^0.34.5"
   },
   "tsup": {

--- a/packages/tools/babel-plugin-syntax-typescript-new/package.json
+++ b/packages/tools/babel-plugin-syntax-typescript-new/package.json
@@ -24,9 +24,6 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.22.5"
   },
-  "devDependencies": {
-    "typescript": "^4.5.2"
-  },
   "tsup": {
     "entry": [
       "src/index.ts"

--- a/packages/tools/error-handler/package.json
+++ b/packages/tools/error-handler/package.json
@@ -20,9 +20,6 @@
   "scripts": {
     "build": "tsup --sourcemap"
   },
-  "devDependencies": {
-    "typescript": "^5.3.2"
-  },
   "tsup": {
     "entry": [
       "src/index.ts"

--- a/packages/tools/vite-plugin-dlight-js/package.json
+++ b/packages/tools/vite-plugin-dlight-js/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
-    "typescript": "^5.3.2",
     "vite": "^4.4.9"
   },
   "tsup": {

--- a/packages/tools/vite-plugin-dlight/package.json
+++ b/packages/tools/vite-plugin-dlight/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
-    "typescript": "^5.3.2",
     "vite": "^4.4.9"
   },
   "tsup": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core/dlight
     devDependencies:
-      typescript:
-        specifier: ^5.2.2
-        version: 5.7.3
       vite:
         specifier: ^6.0.11
         version: 6.0.11(@types/node@20.17.14)
@@ -91,9 +88,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core/babel-preset-dlight
     devDependencies:
-      typescript:
-        specifier: ^5.2.2
-        version: 5.7.3
       vite:
         specifier: ^6.0.11
         version: 6.0.11(@types/node@20.17.14)
@@ -147,9 +141,6 @@ importers:
       '@types/node':
         specifier: ^20.10.5
         version: 20.17.14
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
 
   packages/core/dlight:
     dependencies:
@@ -184,9 +175,6 @@ importers:
       '@vitest/ui':
         specifier: ^0.34.5
         version: 0.34.7(vitest@0.34.6)
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
       vitest:
         specifier: ^0.34.5
         version: 0.34.6(@vitest/ui@0.34.7)
@@ -209,9 +197,6 @@ importers:
       '@types/node':
         specifier: ^20.10.5
         version: 20.17.14
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
 
   packages/core/transpiler/view-parser:
     dependencies:
@@ -228,9 +213,6 @@ importers:
       '@vitest/ui':
         specifier: ^0.34.5
         version: 0.34.7(vitest@0.34.6)
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
       vitest:
         specifier: ^0.34.5
         version: 0.34.6(@vitest/ui@0.34.7)
@@ -246,10 +228,6 @@ importers:
       '@babel/helper-plugin-utils':
         specifier: ^7.22.5
         version: 7.26.5
-    devDependencies:
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
 
   packages/tools/create-dlightjs:
     dependencies:
@@ -260,11 +238,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
 
-  packages/tools/error-handler:
-    devDependencies:
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
+  packages/tools/error-handler: {}
 
   packages/tools/eslint-plugin-dlight: {}
 
@@ -283,9 +257,6 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
       vite:
         specifier: ^4.4.9
         version: 4.5.5(@types/node@20.17.14)
@@ -305,9 +276,6 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
-      typescript:
-        specifier: ^5.3.2
-        version: 5.7.3
       vite:
         specifier: ^4.4.9
         version: 4.5.5(@types/node@20.17.14)
@@ -2750,11 +2718,6 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
-
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -5457,8 +5420,6 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
-
-  typescript@4.9.5: {}
 
   typescript@5.7.3: {}
 


### PR DESCRIPTION
Use typescript as a workspace-wide dependency, with a single version
