### PR TITLE
fix: allow optional params to be passed to dlightPlugin

### DIFF
--- a/.changeset/little-hotels-design.md
+++ b/.changeset/little-hotels-design.md
@@ -1,0 +1,5 @@
+---
+"bun-plugin-dlight": minor
+---
+
+Fix optional params can be passed to dlightPlugin

--- a/packages/tools/bun-plugin-dlight/src/index.ts
+++ b/packages/tools/bun-plugin-dlight/src/index.ts
@@ -6,9 +6,9 @@ export const dlightPlugin = ({
   filter = /\.(view|model)\.[tj]s$/,
   options = {},
 }: {
-  filter: RegExp
-  options: DLightOption
-}): BunPlugin => ({
+  filter?: RegExp
+  options?: DLightOption
+} = {}): BunPlugin => ({
   name: "bun-plugin-dlight",
   setup(build) {
     build.onLoad({ filter }, async args => {

--- a/packages/tools/eslint-plugin-dlight/package.json
+++ b/packages/tools/eslint-plugin-dlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-dlight",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.0",
   "description": "DLight eslint plugin",
   "author": {
     "name": "IanDx",


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #117** 👈
  * **PR #118**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)