### PR TITLE
chore: don't minify dlight dist files

### DIFF
--- a/.changeset/cold-wombats-attend.md
+++ b/.changeset/cold-wombats-attend.md
@@ -1,0 +1,5 @@
+---
+"@dlightjs/dlight": patch
+---
+
+Don't minify the transpiled js in dist folder

--- a/packages/core/dlight/package.json
+++ b/packages/core/dlight/package.json
@@ -35,6 +35,6 @@
       "esm"
     ],
     "clean": true,
-    "minify": true
+    "minify": false
   }
 }


### PR DESCRIPTION
Let consuming code minify if needed, rather than assuming it for the user.