### PR TITLE
fix: use attribute map in setStaticHTMLProp

### DIFF
--- a/packages/core/transpiler/view-generator/src/HelperGenerators/HTMLPropGenerator.ts
+++ b/packages/core/transpiler/view-generator/src/HelperGenerators/HTMLPropGenerator.ts
@@ -394,9 +394,10 @@ export default class HTMLPropGenerator extends ForwardPropGenerator {
       }
       return this.setHTMLEvent(dlNodeName, eventName, value)
     }
+    if (this.alterAttributeMap[attrName]) {
+      attrName = this.alterAttributeMap[attrName]
+    }
     if (this.isInternalAttribute(tag, attrName)) {
-      if (attrName === "class") attrName = "className"
-      else if (attrName === "for") attrName = "htmlFor"
       return this.setHTMLProp(dlNodeName, attrName, value)
     }
     return this.setHTMLAttr(dlNodeName, attrName, value)


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #126** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)